### PR TITLE
Fix editor toolbar layout

### DIFF
--- a/scripts/apps/editor/editor.css
+++ b/scripts/apps/editor/editor.css
@@ -5,7 +5,7 @@
 /* The main app window, provided by UIComponents, is a flex-column.
    The .app-main area within it is a flex-row by default.
    We need to override .app-main for the editor to be a flex-column. */
-#text-editor-app-container .app-main {
+#text-editor-app-container > .app-main {
     display: flex;
     flex-direction: column; /* Stack header, toolbar, and content vertically */
     gap: var(--spacing-sm);


### PR DESCRIPTION
## Summary
- force text editor's main layout to be column-based

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688503f7798483318b58d446fa8099e1